### PR TITLE
fix: Enable single cell copy in ag grid tables

### DIFF
--- a/src/Components/EquipmentListView/EquipmentListTable.tsx
+++ b/src/Components/EquipmentListView/EquipmentListTable.tsx
@@ -235,7 +235,6 @@ function EquipmentListTable({
                     headerHeight={48}
                     rowHeight={35}
                     enableRangeSelection
-                    suppressCopySingleCellRanges
                 />
             </TableContainer>
         </Wrapper>

--- a/src/Components/JIP33Table/JIP33Table.tsx
+++ b/src/Components/JIP33Table/JIP33Table.tsx
@@ -220,7 +220,6 @@ function JIP33Table({
                         headerHeight={48}
                         rowHeight={35}
                         enableRangeSelection
-                        suppressCopySingleCellRanges
                     />
                 </TableContainer>
             </Wrapper>

--- a/src/Components/TagComparisonTable/TagComparisonTable.tsx
+++ b/src/Components/TagComparisonTable/TagComparisonTable.tsx
@@ -132,7 +132,6 @@ function TagComparisonTable({ tags }: Props) {
                         headerHeight={48}
                         rowHeight={35}
                         enableRangeSelection
-                        suppressCopySingleCellRanges
                         sideBar={toggleSideBar()}
                     />
                 </TableContainer>


### PR DESCRIPTION
Remove suppressCopySingleCellRanges property from tables